### PR TITLE
Fix test failed on travis

### DIFF
--- a/examples/gcs.rb
+++ b/examples/gcs.rb
@@ -1,7 +1,8 @@
 task :task1 do
+  param :bucket, type: :string, auto_bind: true, required: true
   param :day, type: :time, auto_bind: true, required: true
   output do
-    target(:gcs_file, bucket: "tumugi-plugin-gcs", key: "test_#{day.strftime('%Y%m%d')}.txt")
+    target(:gcs_file, bucket: bucket, key: "test_#{day.strftime('%Y%m%d')}.txt")
   end
   run do
     log 'task1#run'

--- a/lib/tumugi/plugin/gcs/gcs_file_system.rb
+++ b/lib/tumugi/plugin/gcs/gcs_file_system.rb
@@ -154,6 +154,28 @@ module Tumugi
           [ uri.host, uri.path[1..-1] ]
         end
 
+        def create_bucket(bucket)
+          unless bucket_exist?(bucket)
+            b = Google::Apis::StorageV1::Bucket.new(name: bucket)
+            @client.insert_bucket(@project_id, b)
+            true
+          else
+            false
+          end
+        rescue => e
+          raise Tumugi::FileSystemError.new(e.message)
+        end
+
+        def remove_bucket(bucket)
+          if bucket_exist?(bucket)
+            @client.delete_bucket(bucket)
+          else
+            false
+          end
+        rescue => e
+          raise Tumugi::FileSystemError.new(e.message)
+        end
+
         private
 
         def obj_exist?(bucket, key)

--- a/lib/tumugi/plugin/gcs/gcs_file_system.rb
+++ b/lib/tumugi/plugin/gcs/gcs_file_system.rb
@@ -169,6 +169,7 @@ module Tumugi
         def remove_bucket(bucket)
           if bucket_exist?(bucket)
             @client.delete_bucket(bucket)
+            true
           else
             false
           end
@@ -176,18 +177,18 @@ module Tumugi
           raise Tumugi::FileSystemError.new(e.message)
         end
 
-        private
-
-        def obj_exist?(bucket, key)
-          @client.get_object(bucket, key)
+        def bucket_exist?(bucket)
+          @client.get_bucket(bucket)
           true
         rescue => e
           return false if e.status_code == 404
           raise Tumugi::FileSystemError.new(e.message)
         end
 
-        def bucket_exist?(bucket)
-          @client.get_bucket(bucket)
+        private
+
+        def obj_exist?(bucket, key)
+          @client.get_object(bucket, key)
           true
         rescue => e
           return false if e.status_code == 404

--- a/test/tumugi/plugin/gcs/gcs_file_system_test.rb
+++ b/test/tumugi/plugin/gcs/gcs_file_system_test.rb
@@ -163,4 +163,13 @@ class Tumugi::Plugin::GCSFileSystemTest < Test::Unit::TestCase
       end
     end
   end
+
+  test "bucket releated methods" do
+    bucket = "tumugi-plugin-gcs-#{SecureRandom.hex(10)}"
+    assert_false(@fs.bucket_exist?(bucket))
+    assert_true(@fs.create_bucket(bucket))
+    assert_true(@fs.bucket_exist?(bucket))
+    assert_true(@fs.remove_bucket(bucket))
+    assert_false(@fs.bucket_exist?(bucket))
+  end
 end

--- a/test/tumugi/plugin/gcs/gcs_file_system_test.rb
+++ b/test/tumugi/plugin/gcs/gcs_file_system_test.rb
@@ -4,8 +4,9 @@ require 'tumugi/plugin/gcs/gcs_file_system'
 class Tumugi::Plugin::GCSFileSystemTest < Test::Unit::TestCase
   setup do
     @fs = Tumugi::Plugin::GCS::GCSFileSystem.new(credential)
+    @bucket = "tumugi-plugin-gcs-#{SecureRandom.hex(10)}"
+    @fs.create_bucket(@bucket)
 
-    @bucket = 'tumugi-plugin-gcs'
     @keys = [ "file1.txt", "folder/file2.txt"]
     @keys.each do |key|
       @fs.put_string('test', "gs://#{@bucket}/fs_test/#{key}")
@@ -15,84 +16,85 @@ class Tumugi::Plugin::GCSFileSystemTest < Test::Unit::TestCase
   teardown do
     @fs.remove("gs://#{@bucket}/fs_test/")
     @fs.remove("gs://#{@bucket}/fs_dest/")
+    @fs.remove_bucket(@bucket)
   end
 
   sub_test_case "exist?" do
     test "true" do
-      assert_true(@fs.exist?("gs://tumugi-plugin-gcs/fs_test/"))
-      assert_true(@fs.exist?("gs://tumugi-plugin-gcs/fs_test/#{@keys[0]}"))
+      assert_true(@fs.exist?("gs://#{@bucket}/fs_test/"))
+      assert_true(@fs.exist?("gs://#{@bucket}/fs_test/#{@keys[0]}"))
     end
 
     test "false" do
-      assert_false(@fs.exist?("gs://tumugi-plugin-gcs/fs_test/not_found_dir/"))
-      assert_false(@fs.exist?("gs://tumugi-plugin-gcs/fs_test/not_found_file.txt"))
+      assert_false(@fs.exist?("gs://#{@bucket}/fs_test/not_found_dir/"))
+      assert_false(@fs.exist?("gs://#{@bucket}/fs_test/not_found_file.txt"))
     end
   end
 
   sub_test_case "remove" do
     test "cannot delete root" do
       assert_raise(Tumugi::FileSystemError) do
-        @fs.remove("gs://tumugi-plugin-gcs")
+        @fs.remove("gs://#{@bucket}")
       end
     end
 
     test "exist file" do
-      assert_true(@fs.remove("gs://tumugi-plugin-gcs/fs_test/#{@keys[0]}"))
+      assert_true(@fs.remove("gs://#{@bucket}/fs_test/#{@keys[0]}"))
     end
 
     test "non exist file" do
-      assert_false(@fs.remove("gs://tumugi-plugin-gcs/fs_test/not_found.txt"))
+      assert_false(@fs.remove("gs://#{@bucket}/fs_test/not_found.txt"))
     end
 
     test "directory without recursive flag" do
       assert_raise(Tumugi::FileSystemError) do
-        @fs.remove("gs://tumugi-plugin-gcs/fs_test/", recursive: false)
+        @fs.remove("gs://#{@bucket}/fs_test/", recursive: false)
       end
     end
 
     test "directory also delete child files" do
-      assert_true(@fs.remove("gs://tumugi-plugin-gcs/fs_test/"))
-      assert_equal(0, @fs.entries("gs://tumugi-plugin-gcs/fs_test/").count)
+      assert_true(@fs.remove("gs://#{@bucket}/fs_test/"))
+      assert_equal(0, @fs.entries("gs://#{@bucket}/fs_test/").count)
     end
   end
 
   sub_test_case "mkdir" do
     test "return true when success" do
-      assert_true(@fs.mkdir("gs://tumugi-plugin-gcs/fs_test/new_dir/"))
+      assert_true(@fs.mkdir("gs://#{@bucket}/fs_test/new_dir/"))
     end
 
     sub_test_case "path is already exist" do
       test "raise error if raise_if_exist flag is true" do
         assert_raise(Tumugi::FileAlreadyExistError) do
-          @fs.mkdir("gs://tumugi-plugin-gcs/fs_test/", raise_if_exist: true)
+          @fs.mkdir("gs://#{@bucket}/fs_test/", raise_if_exist: true)
         end
       end
 
       test "raise error if path is not a directory" do
         assert_raise(Tumugi::NotADirectoryError) do
-          @fs.mkdir("gs://tumugi-plugin-gcs/fs_test/#{@keys[0]}")
+          @fs.mkdir("gs://#{@bucket}/fs_test/#{@keys[0]}")
         end
       end
 
       test "return false" do
-        assert_false(@fs.mkdir("gs://tumugi-plugin-gcs/fs_test/"))
+        assert_false(@fs.mkdir("gs://#{@bucket}/fs_test/"))
       end
     end
   end
 
   data({
-    "root" => [ true, "gs://tumugi-plugin-gcs" ],
-    "exist" => [ true, "gs://tumugi-plugin-gcs/fs_test/" ],
-    "prefix" => [ true, "gs://tumugi-plugin-gcs/fs_test/folder" ],
-    "not_a_folder" => [ false, "gs://tumugi-plugin-gcs/fs_test/not_a_folder" ]
+    "root" => [ true, "" ],
+    "exist" => [ true, "fs_test/" ],
+    "prefix" => [ true, "fs_test/folder" ],
+    "not_a_folder" => [ false, "fs_test/not_a_folder" ]
   })
   test "directory?" do |(expected, path)|
-    assert_equal(expected, @fs.directory?(path))
+    assert_equal(expected, @fs.directory?("gs://#{@bucket}/#{path}"))
   end
 
   sub_test_case 'entries' do
     test 'path has entries' do
-      entries = @fs.entries("gs://tumugi-plugin-gcs/fs_test/")
+      entries = @fs.entries("gs://#{@bucket}/fs_test/")
       assert_equal(@keys.count, entries.count)
       @keys.each_with_index do |key, i|
         assert_equal(@bucket, entries[i].bucket)
@@ -101,15 +103,15 @@ class Tumugi::Plugin::GCSFileSystemTest < Test::Unit::TestCase
     end
 
     test 'path has no entry' do
-      entries = @fs.entries("gs://tumugi-plugin-gcs/fs_test/no_entries/")
+      entries = @fs.entries("gs://#{@bucket}/fs_test/no_entries/")
       assert_true(entries.empty?)
     end
   end
 
   sub_test_case "move" do
     test 'directory' do
-      src_path = "gs://tumugi-plugin-gcs/fs_test/"
-      dest_path = "gs://tumugi-plugin-gcs/fs_dest/"
+      src_path = "gs://#{@bucket}/fs_test/"
+      dest_path = "gs://#{@bucket}/fs_dest/"
 
       @fs.move(src_path, dest_path)
 
@@ -124,20 +126,20 @@ class Tumugi::Plugin::GCSFileSystemTest < Test::Unit::TestCase
   end
 
   test 'upload' do
-    new_file_path = "gs://tumugi-plugin-gcs/fs_test/new_file.txt"
+    new_file_path = "gs://#{@bucket}/fs_test/new_file.txt"
     @fs.upload(StringIO.new('upload'), new_file_path)
     assert_true(@fs.exist?(new_file_path))
   end
 
   test 'download' do
-    @fs.download("gs://tumugi-plugin-gcs/fs_test/#{@keys[0]}", 'tmp/download.txt')
+    @fs.download("gs://#{@bucket}/fs_test/#{@keys[0]}", 'tmp/download.txt')
     assert_equal('test', File.read('tmp/download.txt'))
   end
 
   sub_test_case 'copy' do
     test 'directory' do
-      src_path = "gs://tumugi-plugin-gcs/fs_test/"
-      dest_path = "gs://tumugi-plugin-gcs/fs_dest/"
+      src_path = "gs://#{@bucket}/fs_test/"
+      dest_path = "gs://#{@bucket}/fs_dest/"
 
       @fs.copy(src_path, dest_path)
 


### PR DESCRIPTION
Travis runs multi ruby version test concurrently, so we have to use different bucket for each test to avoid file create/delete conflict between multiple concurrent test jobs.
