### PR TITLE
Support custom filesystem for GoogleCloudStorageFileTarget

### DIFF
--- a/lib/tumugi/plugin/google_cloud_storage/atomic_file.rb
+++ b/lib/tumugi/plugin/google_cloud_storage/atomic_file.rb
@@ -4,13 +4,13 @@ module Tumugi
   module Plugin
     module GoogleCloudStorage
       class AtomicFile < Tumugi::AtomicFile
-        def initialize(path, client)
+        def initialize(path, fs)
           super(path)
-          @client = client
+          @fs = fs
         end
 
         def move_to_final_destination(temp_file)
-          @client.upload(temp_file, path)
+          @fs.upload(temp_file, path)
         end
       end
     end

--- a/lib/tumugi/plugin/target/google_cloud_storage_file.rb
+++ b/lib/tumugi/plugin/target/google_cloud_storage_file.rb
@@ -12,10 +12,11 @@ module Tumugi
 
       attr_reader :bucket, :key, :path
 
-      def initialize(bucket:, key:)
+      def initialize(bucket:, key:, fs: nil)
         @bucket = bucket
         @key = key
         @path = "gs://#{File.join(bucket, key)}"
+        @fs = fs unless fs.nil?
         log "bucket='#{bucket}, key='#{key}'"
       end
 


### PR DESCRIPTION
Related to https://github.com/tumugi/tumugi-plugin-bigquery/pull/15

When developer use `GoogleCloudStorageFileTarget` in custom code, it's useful to support custom FileSystem, especially avoid duplicate config section for GCP authentication.
