### PR TITLE
Change ruby version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 rvm:
   - 2.1
-  - 2.2
   - 2.3.1
   - jruby-9.1.2.0
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.1.10
-  - 2.2.5
+  - 2.1
+  - 2.2
   - 2.3.1
-  - ruby-head
-  - jruby-9.0.5.0
+  - jruby-9.1.2.0
 before_install:
   - gem install bundler
-matrix:
-  allow_failures:
-    - rvm: ruby-head


### PR DESCRIPTION
- Do not set specific version of ruby 2.1. Use travis's default version.
- Do not test with ruby 2.2 and ruby-head. Sometimes it failed, but it's too much for this plugin.
