### PR TITLE
Change tumugi dependency version

### DIFF
--- a/tumugi-plugin-google_cloud_storage.gemspec
+++ b/tumugi-plugin-google_cloud_storage.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_runtime_dependency "tumugi", "~> 0.5.1"
+  spec.add_runtime_dependency "tumugi", ">= 0.5.1"
   spec.add_runtime_dependency "google-api-client", "~> 0.9.3"
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
Change dependency from `~> 0.5.0` to `>= 0.5.0`, because plugin can run with future tumugi release, such as `0.6.0`.
